### PR TITLE
Synchronized sets should always be accessed in synchronized block

### DIFF
--- a/src/main/java/org/dreesbach/ticketing/id/IdGenerator.java
+++ b/src/main/java/org/dreesbach/ticketing/id/IdGenerator.java
@@ -126,7 +126,9 @@ public final class IdGenerator {
      * @return number of unique reservation IDs in use
      */
     public static int numUniqueReservationIds() {
-        return RESERVATION_IDS_IN_USE.size();
+        synchronized (RESERVATION_IDS_IN_USE) {
+            return RESERVATION_IDS_IN_USE.size();
+        }
     }
 
     /**


### PR DESCRIPTION
Per the documentation on Collections.synchronizedSet, all access to the set MUST be synchronized on the collection. So adding that to the one place it was still missing.

This is also what probably caused the occasional test failures for the IDS_IN_USE set.