### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,6 +4,7 @@
 name: Java CI with Maven
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   push:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/HerbCSO/ticketing/security/code-scanning/1](https://github.com/HerbCSO/ticketing/security/code-scanning/1)

The recommended fix is to explicitly set the permissions key at the root level of the workflow (above the `jobs:` block), specifying the least privileged necessary setting. In this context, setting:
```yaml
permissions:
  contents: read
```
at the root level will limit the GITHUB_TOKEN to read-only access to repository contents for all jobs in the workflow, which is sufficient given the steps included. No changes are needed to the job logic or steps. The fix should be inserted between the `name:` definition and the `on:` block (ideally right after the `name:` line or before `on:` at line 5/6).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
