### PR TITLE
Fix SeatHold leak and missing synchronization in reserveSeats

### DIFF
--- a/src/main/java/org/dreesbach/ticketing/TicketServiceImpl.java
+++ b/src/main/java/org/dreesbach/ticketing/TicketServiceImpl.java
@@ -1,5 +1,7 @@
 package org.dreesbach.ticketing;
 
+import org.dreesbach.ticketing.id.IdGenerator;
+
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Iterator;
@@ -121,7 +123,7 @@ public final class TicketServiceImpl implements TicketService {
      * @throws IllegalStateException when a SeatHold is not found
      */
     @Override
-    public String reserveSeats(final int seatHoldId, final String customerEmail) {
+    public synchronized String reserveSeats(final int seatHoldId, final String customerEmail) {
         checkArgument(seatHoldId > 0, "seatHoldId must be > 0");
         checkEmailParam(customerEmail);
         SeatHold seatHold;
@@ -134,7 +136,13 @@ public final class TicketServiceImpl implements TicketService {
                 throw new IllegalStateException("SeatHold ID [" + seatHoldId + "] is expired");
             }
         }
-        return venue.reserve(seatHold);
+        String reservationCode = venue.reserve(seatHold);
+        // The SeatHold has now been consumed by a completed reservation - stop tracking it and retire its ID so we don't
+        // leak map entries / IDs for every successful reservation. We must not call seatHold.remove() here, since that
+        // would try to cancel the hold on seats that are now reserved rather than held.
+        seatHolds.remove(seatHoldId);
+        IdGenerator.retireId(seatHoldId);
+        return reservationCode;
     }
 
     /**

--- a/src/test/java/org/dreesbach/ticketing/TicketServiceImplTest.java
+++ b/src/test/java/org/dreesbach/ticketing/TicketServiceImplTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,6 +29,11 @@ class TicketServiceImplTest {
     private static final int NUM_COLS = 3;
     private static final long WAIT_FOR_EXPIRATION_IN_MS = 100L;
     private static final Duration DEFAULT_SEAT_HOLD_CHECK_DURATION = Duration.ofMillis(1);
+    /**
+     * In {@link #stadiumSizedVenue()}, the tolerance for how many seat holds are allowed to expire before they could be
+     * reserved (e.g. due to slow test hardware), out of ~9,500 holds created.
+     */
+    private static final int MAX_ACCEPTABLE_UNRESERVED_HOLDS = 100;
     private static Venue persistentDefaultVenue;
     private static TicketService persistentTicketService;
     private Venue defaultVenue;
@@ -157,6 +163,26 @@ class TicketServiceImplTest {
     }
 
     @Test
+    void reserveSeatsStopsTrackingTheSeatHold() {
+        SeatHold seatHold = ticketService.findAndHoldSeats(2, CUSTOMER_EMAIL);
+        assertEquals(2,
+                ((TicketServiceImpl) ticketService).numSeatsHeld(),
+                "Held seats should be tracked as held prior to reservation"
+        );
+        ticketService.reserveSeats(seatHold.getId(), CUSTOMER_EMAIL);
+        assertEquals(0,
+                ((TicketServiceImpl) ticketService).numSeatsHeld(),
+                "Reserved seats should no longer be tracked as held once reserved"
+        );
+        // Reserving the same (now consumed) SeatHold ID again should fail cleanly instead of finding a stale entry.
+        TestUtil.testException(
+                IllegalStateException.class,
+                () -> ticketService.reserveSeats(seatHold.getId(), CUSTOMER_EMAIL),
+                "SeatHold ID [" + seatHold.getId() + "] not found"
+        );
+    }
+
+    @Test
     void reserveUnheldSeat() {
         TestUtil.testException(
                 IllegalArgumentException.class,
@@ -246,12 +272,17 @@ class TicketServiceImplTest {
                 System.out.println(counter + " SeatHolds reserved");
             }
         }
+        final int numReserved = counter;
         assertAll("check postconditions",
                 () -> assertEquals(0, venue.getAvailableNumSeats(), "Expcted 0 seats left"),
                 () -> assertEquals(0, localTicketService.numSeatsAvailable(), "Expected 0 seats available"),
-                () -> assertThat("Expected more than 1,000 seat holds to still not be expired",
+                () -> assertThat("Expected the vast majority of seat holds to have been reserved before they could expire",
+                        numReserved,
+                        greaterThanOrEqualTo(seatHolds.size() - MAX_ACCEPTABLE_UNRESERVED_HOLDS)
+                ),
+                () -> assertThat("Successfully reserved SeatHolds should no longer be tracked as held",
                         ((TicketServiceImpl) localTicketService).numSeatsHeld(),
-                        greaterThanOrEqualTo(1_000)
+                        lessThan(venue.getTotalNumSeats() / 10)
                 )
         );
     }


### PR DESCRIPTION
## Summary
- `TicketServiceImpl.reserveSeats()` never removed its `SeatHold` from the `seatHolds` tracking map or retired its ID in `IdGenerator` after a successful reservation. Every completed sale permanently leaked a map entry and an ID, and `numSeatsHeld()` kept counting already-reserved seats as "held".
- `reserveSeats()` was not `synchronized`, unlike `findAndHoldSeats()` and the background `expireSeatHolds()` task. This allowed a hold to expire (cancelling its seats) concurrently with a reservation for that same hold, which can throw an uncaught exception from inside the scheduled expiration task and silently disable all future expiration for that `TicketServiceImpl` instance.

## Changes
- Made `reserveSeats()` `synchronized`, and have it remove the consumed `SeatHold` from the map and retire its ID via `IdGenerator.retireId()` after a successful reservation.
- Added `reserveSeatsStopsTrackingTheSeatHold()` regression test verifying reserved holds are no longer tracked as held, and that re-reserving the same (consumed) hold ID now fails cleanly with "not found" instead of hitting a stale entry.
- Updated `stadiumSizedVenue()`'s assertions, which had inadvertently been asserting on the leak itself (`numSeatsHeld() >= 1000` was trivially true only because reserved holds were never removed). It now asserts that the vast majority of holds were reserved before expiring, and that `numSeatsHeld()` correctly drops once holds are reserved.

## Test plan
- [x] `mvn test` - all 125 tests pass
- [x] `mvn verify` - Checkstyle (0 violations) and SpotBugs both pass