### PR TITLE
Fix printSeats() crash on narrow venues and dead RNG reseed counter

### DIFF
--- a/src/main/java/org/dreesbach/ticketing/RectangularVenue.java
+++ b/src/main/java/org/dreesbach/ticketing/RectangularVenue.java
@@ -225,7 +225,9 @@ final class RectangularVenue implements Venue {
     @Override
     public void printSeats() {
         String header = " STAGE ";
-        int padding = (seatsPerRow * 2 - header.length()) / 2;
+        // Guard against small venues where the row is narrower than the header, which would otherwise produce a negative
+        // padding and blow up Collections.nCopies().
+        int padding = Math.max(0, (seatsPerRow * 2 - header.length()) / 2);
         System.out.println(String.join("", Collections.nCopies(padding, "-")) + " STAGE " + String.join("",
                 Collections.nCopies(padding, "-")
         ));

--- a/src/main/java/org/dreesbach/ticketing/id/IdGenerator.java
+++ b/src/main/java/org/dreesbach/ticketing/id/IdGenerator.java
@@ -21,9 +21,10 @@ public final class IdGenerator {
      */
     public static final int MAX_RESERVATION_CODE_LENGTH = 6;
     /**
-     * Max number of calls to the {@link rng} to allow before re-seeding it.
+     * Max number of calls to the {@link rng} to allow before re-seeding it. Package-private (rather than private) so tests
+     * can verify {@link callCounter} cycles correctly without duplicating this value.
      */
-    private static final int MAX_CALL_COUNT_BEFORE_RESET = 10_000;
+    static final int MAX_CALL_COUNT_BEFORE_RESET = 10_000;
     /**
      * Random number generator for this class.
      */
@@ -160,12 +161,25 @@ public final class IdGenerator {
     }
 
     /**
-     * Utility method to re-seed the {@link rng}.
+     * Utility method to re-seed the {@link rng} every {@value MAX_CALL_COUNT_BEFORE_RESET} calls.
+     * <p>
+     * Synchronized so that concurrent callers can't race on incrementing {@link callCounter}, which would otherwise let the
+     * threshold check pass multiple times (or not fire at all) under load.
      */
-    private static void reseedRng() {
-        if (callCounter % MAX_CALL_COUNT_BEFORE_RESET == 0) {
+    private static synchronized void reseedRng() {
+        callCounter++;
+        if (callCounter >= MAX_CALL_COUNT_BEFORE_RESET) {
             rng.setSeed(Instant.now().getEpochSecond());
             callCounter = 0;
         }
+    }
+
+    /**
+     * Test-only accessor for the current {@link callCounter} value.
+     *
+     * @return the number of calls since the {@link rng} was last re-seeded
+     */
+    static synchronized int getCallCounter() {
+        return callCounter;
     }
 }

--- a/src/test/java/org/dreesbach/ticketing/RectangularVenueSimpleSeatPickingStrategyTest.java
+++ b/src/test/java/org/dreesbach/ticketing/RectangularVenueSimpleSeatPickingStrategyTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -17,6 +18,7 @@ import java.util.List;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -121,6 +123,16 @@ class RectangularVenueSimpleSeatPickingStrategyTest {
                         () -> venue.getYPosition(10),
                         "Too high a row number throws exception"
                 )
+        );
+    }
+
+    @DisplayName("printSeats on narrow venues")
+    @ParameterizedTest(name = "printSeats should not throw for a venue with [{0}] seat(s) per row")
+    @ValueSource(ints = { 1, 2, 3 })
+    void printSeatsHandlesNarrowVenues(int numSeatsPerRow) {
+        venue = new RectangularVenue(1, numSeatsPerRow, seatPickingStrategy);
+        assertDoesNotThrow(venue::printSeats,
+                "printSeats should not throw even when the row is narrower than the ' STAGE ' header"
         );
     }
 

--- a/src/test/java/org/dreesbach/ticketing/id/IdGeneratorTest.java
+++ b/src/test/java/org/dreesbach/ticketing/id/IdGeneratorTest.java
@@ -102,6 +102,19 @@ class IdGeneratorTest {
     }
 
     @Test
+    void callCounterAdvancesAndWrapsOnEachCall() {
+        int before = IdGenerator.getCallCounter();
+        IdGenerator.generateUniqueIntId();
+        int after = IdGenerator.getCallCounter();
+        int expected = (before + 1) % IdGenerator.MAX_CALL_COUNT_BEFORE_RESET;
+        assertEquals(expected,
+                after,
+                "callCounter should advance by one on each call (wrapping to 0 at the reseed threshold) instead of "
+                        + "staying fixed"
+        );
+    }
+
+    @Test
     void testUniqueIntIdsGenerated() {
         Set<Integer> ids = new HashSet<>();
         for (int i = 0; i < NUM_ID_GENERATION_ITERATIONS; i++) {


### PR DESCRIPTION
## Summary
- `RectangularVenue.printSeats()` computed header padding as `(seatsPerRow * 2 - header.length()) / 2`, which goes negative whenever a row has fewer than 3 seats (narrower than the `" STAGE "` label). `Collections.nCopies()` then throws `IllegalArgumentException`, so any 1- or 2-seat-per-row venue crashes on `printSeats()`.
- `IdGenerator.reseedRng()` was supposed to re-seed the RNG every `MAX_CALL_COUNT_BEFORE_RESET` (10,000) calls, tracked via `callCounter`. `callCounter` was declared but never incremented anywhere, so it stayed at 0 forever and the RNG was re-seeded on *every single call* instead of every 10,000 as intended, defeating the documented tuning/perf intent.

## Changes
- Clamp `printSeats()`'s padding calculation to a minimum of 0.
- `reseedRng()` now increments `callCounter` and only re-seeds once it reaches the threshold, resetting it back to 0 at that point. Made the method `synchronized` since it's shared static state that can be reached concurrently from both `generateUniqueIntId()` and `generateReservationCode()`.
- Made `MAX_CALL_COUNT_BEFORE_RESET` package-private (it's `static final`, so this doesn't affect Checkstyle's `VisibilityModifier` check) and added a package-private `getCallCounter()` test accessor, following this codebase's existing convention of package-private test hooks (e.g. `RectangularVenue.getYPosition`/`getGoodness`).
- Added `printSeatsHandlesNarrowVenues` (parameterized over 1/2/3 seats-per-row) to `RectangularVenueSimpleSeatPickingStrategyTest`.
- Added `callCounterAdvancesAndWrapsOnEachCall` to `IdGeneratorTest`, which fails against the old code (counter stuck at 0) and passes against the fix.

## Test plan
- [x] `mvn test` - all 129 tests pass (4 new)
- [x] `mvn verify` - Checkstyle (0 violations) and SpotBugs both pass