### PR TITLE
Give TicketService a shutdown path for its background thread

### DIFF
--- a/src/main/java/org/dreesbach/ticketing/TicketService.java
+++ b/src/main/java/org/dreesbach/ticketing/TicketService.java
@@ -3,7 +3,7 @@ package org.dreesbach.ticketing;
 /**
  * Provides an interface for reserving tickets in high-demand performance locations.
  */
-public interface TicketService {
+public interface TicketService extends AutoCloseable {
     /**
      * The number of seats in the venue that are neither held nor reserved.
      *
@@ -28,4 +28,14 @@ public interface TicketService {
      * @return a reservation confirmation code
      */
     String reserveSeats(int seatHoldId, String customerEmail);
+
+    /**
+     * Releases any resources held by this service (e.g. background threads used to expire seat holds). Once closed, a
+     * {@link TicketService} should no longer be used.
+     * <p>
+     * Overridden here (rather than inherited as-is from {@link AutoCloseable}) to declare no checked exception, since
+     * implementations aren't expected to need one.
+     */
+    @Override
+    void close();
 }

--- a/src/main/java/org/dreesbach/ticketing/TicketServiceImpl.java
+++ b/src/main/java/org/dreesbach/ticketing/TicketServiceImpl.java
@@ -176,6 +176,23 @@ public final class TicketServiceImpl implements TicketService {
     }
 
     /**
+     * Shuts down the background thread that expires {@link SeatHold}s. Once closed, this instance should no longer be used.
+     */
+    @Override
+    public void close() {
+        seatHoldExpiration.shutdown();
+    }
+
+    /**
+     * Whether the background seat hold expiration thread has been shut down.
+     *
+     * @return {@code true} if {@link close()} has been called
+     */
+    boolean isClosed() {
+        return seatHoldExpiration.isShutdown();
+    }
+
+    /**
      * Removes expired {@link SeatHold}s.
      */
     private synchronized void expireSeatHolds() {

--- a/src/test/java/org/dreesbach/ticketing/TicketServiceImplTest.java
+++ b/src/test/java/org/dreesbach/ticketing/TicketServiceImplTest.java
@@ -1,6 +1,8 @@
 package org.dreesbach.ticketing;
 
 import org.dreesbach.ticketing.id.IdGenerator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -46,11 +48,21 @@ class TicketServiceImplTest {
         persistentTicketService = new TicketServiceImpl(persistentDefaultVenue);
     }
 
+    @AfterAll
+    public static void tearDownAll() {
+        persistentTicketService.close();
+    }
+
     @BeforeEach
     public void setup() {
         SeatPickingStrategy<RectangularVenue> seatPickingStrategy = new RectangularVenueSimpleSeatPickingStrategy();
         defaultVenue = new RectangularVenue(NUM_ROWS, NUM_COLS, seatPickingStrategy);
         ticketService = new TicketServiceImpl(defaultVenue);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ticketService.close();
     }
 
     @Test
@@ -199,91 +211,104 @@ class TicketServiceImplTest {
     }
 
     @Test
+    void closeShutsDownSeatHoldExpirationThread() {
+        TicketServiceImpl impl = (TicketServiceImpl) ticketService;
+        assertFalse(impl.isClosed(), "Should not be closed until close() is called");
+        ticketService.close();
+        assertTrue(impl.isClosed(), "Should be closed after close() is called");
+    }
+
+    @Test
     void ensureSeatHoldsExpire() throws InterruptedException {
-        TicketService ticketServiceWithImmediateExpiration =
-                new TicketServiceImpl(defaultVenue, DEFAULT_SEAT_HOLD_CHECK_DURATION, Duration.ZERO);
-        SeatHold seatHold = ticketServiceWithImmediateExpiration.findAndHoldSeats(2, CUSTOMER_EMAIL);
-        assertTrue(seatHold.expired(), "SeatHold should expire immediately");
-        Thread.sleep(WAIT_FOR_EXPIRATION_IN_MS); // Ensure that the #expireSeatHolds method has had time to run
-        assertEquals(0,
-                ((TicketServiceImpl) ticketServiceWithImmediateExpiration).numSeatsHeld(),
-                "No seats should be held anymore"
-        );
-        defaultVenue.printSeats();
+        try (TicketService ticketServiceWithImmediateExpiration =
+                new TicketServiceImpl(defaultVenue, DEFAULT_SEAT_HOLD_CHECK_DURATION, Duration.ZERO)) {
+            SeatHold seatHold = ticketServiceWithImmediateExpiration.findAndHoldSeats(2, CUSTOMER_EMAIL);
+            assertTrue(seatHold.expired(), "SeatHold should expire immediately");
+            Thread.sleep(WAIT_FOR_EXPIRATION_IN_MS); // Ensure that the #expireSeatHolds method has had time to run
+            assertEquals(0,
+                    ((TicketServiceImpl) ticketServiceWithImmediateExpiration).numSeatsHeld(),
+                    "No seats should be held anymore"
+            );
+            defaultVenue.printSeats();
+        }
     }
 
     @Test
     void reserveExpiredSeats() throws InterruptedException {
-        TicketService ticketServiceWithImmediateExpiration =
-                new TicketServiceImpl(defaultVenue, DEFAULT_SEAT_HOLD_CHECK_DURATION, Duration.ZERO);
-        SeatHold seatHold = ticketServiceWithImmediateExpiration.findAndHoldSeats(2, CUSTOMER_EMAIL);
-        assertTrue(seatHold.expired(), "SeatHold should expire immediately");
-        Thread.sleep(WAIT_FOR_EXPIRATION_IN_MS); // Ensure that the #expireSeatHolds method has had time to run
-        TestUtil.testException(
-                IllegalStateException.class,
-                () -> ticketServiceWithImmediateExpiration.reserveSeats(seatHold.getId(), CUSTOMER_EMAIL),
-                "SeatHold ID [" + seatHold.getId() + "] not found"
-        );
+        try (TicketService ticketServiceWithImmediateExpiration =
+                new TicketServiceImpl(defaultVenue, DEFAULT_SEAT_HOLD_CHECK_DURATION, Duration.ZERO)) {
+            SeatHold seatHold = ticketServiceWithImmediateExpiration.findAndHoldSeats(2, CUSTOMER_EMAIL);
+            assertTrue(seatHold.expired(), "SeatHold should expire immediately");
+            Thread.sleep(WAIT_FOR_EXPIRATION_IN_MS); // Ensure that the #expireSeatHolds method has had time to run
+            TestUtil.testException(
+                    IllegalStateException.class,
+                    () -> ticketServiceWithImmediateExpiration.reserveSeats(seatHold.getId(), CUSTOMER_EMAIL),
+                    "SeatHold ID [" + seatHold.getId() + "] not found"
+            );
+        }
     }
 
     @Test
     void ensureSeatHoldsDoNotExpireTooSoon() throws InterruptedException {
         final int numSeats = 2;
-        TicketServiceImpl ticketServiceWithSlowExpiration =
-                new TicketServiceImpl(defaultVenue, DEFAULT_SEAT_HOLD_CHECK_DURATION, Duration.ofDays(1));
-        SeatHold seatHold = ticketServiceWithSlowExpiration.findAndHoldSeats(numSeats, CUSTOMER_EMAIL);
-        assertFalse(seatHold.expired(), "SeatHold should not be expired yet");
-        // Bugger - a Mockito spy seems to be unable to catch the fact that the expiration method was called from a separate
-        // thread (the ScheduledExecutorService), so I admit defeat for now and will keep the sleep in here. :/
-        Thread.sleep(WAIT_FOR_EXPIRATION_IN_MS); // Ensure that the #expireSeatHolds method has had time
-        // to run
-        assertEquals(numSeats, ticketServiceWithSlowExpiration.numSeatsHeld(), "Seats should still be held");
-        defaultVenue.printSeats();
+        try (TicketServiceImpl ticketServiceWithSlowExpiration =
+                new TicketServiceImpl(defaultVenue, DEFAULT_SEAT_HOLD_CHECK_DURATION, Duration.ofDays(1))) {
+            SeatHold seatHold = ticketServiceWithSlowExpiration.findAndHoldSeats(numSeats, CUSTOMER_EMAIL);
+            assertFalse(seatHold.expired(), "SeatHold should not be expired yet");
+            // Bugger - a Mockito spy seems to be unable to catch the fact that the expiration method was called from a
+            // separate thread (the ScheduledExecutorService), so I admit defeat for now and will keep the sleep in here. :/
+            Thread.sleep(WAIT_FOR_EXPIRATION_IN_MS); // Ensure that the #expireSeatHolds method has had time
+            // to run
+            assertEquals(numSeats, ticketServiceWithSlowExpiration.numSeatsHeld(), "Seats should still be held");
+            defaultVenue.printSeats();
+        }
     }
 
     @Test
     void stadiumSizedVenue() {
         SeatPickingStrategy<RectangularVenue> seatPickingStrategy = new RectangularVenueSimpleSeatPickingStrategy();
         Venue venue = new RectangularVenue(100, 1_000, seatPickingStrategy);
-        TicketService localTicketService = new TicketServiceImpl(venue, Duration.ofMillis(500), Duration.ofSeconds(2));
-        SecureRandom rnd = new SecureRandom();
-        rnd.setSeed(Instant.now().getEpochSecond());
-        Map<String, SeatHold> seatHolds = new HashMap<>();
-        int counter = 0;
-        while (venue.getAvailableNumSeats() > 0) {
-            String email = "email" + counter;
-            seatHolds.put(email, localTicketService.findAndHoldSeats(rnd.nextInt(20) + 1, email));
-            counter++;
-            if (counter % 1000 == 0) {
-                System.out.println(counter + " SeatHolds created");
-                System.out.println(venue.getAvailableNumSeats() + " seats available out of " + venue.getTotalNumSeats());
+        try (TicketService localTicketService = new TicketServiceImpl(venue, Duration.ofMillis(500), Duration.ofSeconds(2))) {
+            SecureRandom rnd = new SecureRandom();
+            rnd.setSeed(Instant.now().getEpochSecond());
+            Map<String, SeatHold> seatHolds = new HashMap<>();
+            int counter = 0;
+            while (venue.getAvailableNumSeats() > 0) {
+                String email = "email" + counter;
+                seatHolds.put(email, localTicketService.findAndHoldSeats(rnd.nextInt(20) + 1, email));
+                counter++;
+                if (counter % 1000 == 0) {
+                    System.out.println(counter + " SeatHolds created");
+                    System.out.println(venue.getAvailableNumSeats() + " seats available out of " + venue.getTotalNumSeats());
+                }
             }
+            counter = 0;
+            for (Map.Entry<String, SeatHold> seatHold : seatHolds.entrySet()) {
+                try {
+                    localTicketService.reserveSeats(seatHold.getValue().getId(), seatHold.getKey());
+                }
+                catch (IllegalStateException ise) {
+                    counter--;
+                }
+                counter++;
+                if (counter % 1000 == 0) {
+                    System.out.println(counter + " SeatHolds reserved");
+                }
+            }
+            final int numReserved = counter;
+            assertAll("check postconditions",
+                    () -> assertEquals(0, venue.getAvailableNumSeats(), "Expcted 0 seats left"),
+                    () -> assertEquals(0, localTicketService.numSeatsAvailable(), "Expected 0 seats available"),
+                    () -> assertThat("Expected the vast majority of seat holds to have been reserved before they could "
+                                    + "expire",
+                            numReserved,
+                            greaterThanOrEqualTo(seatHolds.size() - MAX_ACCEPTABLE_UNRESERVED_HOLDS)
+                    ),
+                    () -> assertThat("Successfully reserved SeatHolds should no longer be tracked as held",
+                            ((TicketServiceImpl) localTicketService).numSeatsHeld(),
+                            lessThan(venue.getTotalNumSeats() / 10)
+                    )
+            );
         }
-        counter = 0;
-        for (Map.Entry<String, SeatHold> seatHold : seatHolds.entrySet()) {
-            try {
-                localTicketService.reserveSeats(seatHold.getValue().getId(), seatHold.getKey());
-            }
-            catch (IllegalStateException ise) {
-                counter--;
-            }
-            counter++;
-            if (counter % 1000 == 0) {
-                System.out.println(counter + " SeatHolds reserved");
-            }
-        }
-        final int numReserved = counter;
-        assertAll("check postconditions",
-                () -> assertEquals(0, venue.getAvailableNumSeats(), "Expcted 0 seats left"),
-                () -> assertEquals(0, localTicketService.numSeatsAvailable(), "Expected 0 seats available"),
-                () -> assertThat("Expected the vast majority of seat holds to have been reserved before they could expire",
-                        numReserved,
-                        greaterThanOrEqualTo(seatHolds.size() - MAX_ACCEPTABLE_UNRESERVED_HOLDS)
-                ),
-                () -> assertThat("Successfully reserved SeatHolds should no longer be tracked as held",
-                        ((TicketServiceImpl) localTicketService).numSeatsHeld(),
-                        lessThan(venue.getTotalNumSeats() / 10)
-                )
-        );
     }
 }


### PR DESCRIPTION
## Summary
`TicketServiceImpl` starts a `ScheduledThreadPoolExecutor` in its constructor to periodically expire `SeatHold`s, but the class implemented neither `AutoCloseable` nor any `shutdown()` method. Every instance - in production and in the test suite alike - permanently leaked a non-daemon background thread with no way to dispose of it.

## Changes
- `TicketService` now extends `AutoCloseable`, with `close()` re-declared to drop the checked `Exception` (implementations don't need one).
- `TicketServiceImpl.close()` shuts down the seat-hold-expiration executor. Added a package-private `isClosed()` test accessor, following this codebase's existing convention (e.g. `RectangularVenue.getYPosition`/`getGoodness`).
- Updated `TicketServiceImplTest` to actually close the services it creates instead of leaking them: `@AfterEach`/`@AfterAll` for the shared `ticketService`/`persistentTicketService` fields, try-with-resources for the locally-scoped instances in `ensureSeatHoldsExpire`, `reserveExpiredSeats`, `ensureSeatHoldsDoNotExpireTooSoon`, and `stadiumSizedVenue`.
- Added `closeShutsDownSeatHoldExpirationThread` regression test.

## Test plan
- [x] `mvn test` - all 130 tests pass (1 new)
- [x] `mvn verify` - Checkstyle (0 violations) and SpotBugs both pass