### PR TITLE
Clean up remaining minor/style issues

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -5,4 +5,5 @@ name = "java"
 enabled = true
 
   [analyzers.meta]
-  runtime_version = "8"
+  # The project targets Java 24, but DeepSource's Java analyzer only supports OpenJDK 8-21, so this is capped at 21.
+  runtime_version = "21"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4.1.1
-    - name: Set up JDK 1.24
+    - name: Set up JDK 24
       uses: actions/setup-java@v3.13.0
       with:
         java-version: 24

--- a/src/main/java/org/dreesbach/ticketing/RectangularVenue.java
+++ b/src/main/java/org/dreesbach/ticketing/RectangularVenue.java
@@ -104,9 +104,10 @@ final class RectangularVenue implements Venue {
     }
 
     /**
-     * The "goodness" score of the row overall. Ranges from 1 to {@link numRows}.
+     * The "goodness" score contribution of the row. Ranges from 0 (best, front row) to {@code numRows - 1} (worst, back
+     * row).
      *
-     * @param row row number of the seat, from 1 to n
+     * @param row row number of the seat, from 0 to {@code numRows - 1} (inclusive)
      * @return the "goodness" score - relative to the size of the venue, the lower the better, minimum of 0
      */
     double getYPosition(final int row) {
@@ -115,10 +116,11 @@ final class RectangularVenue implements Venue {
     }
 
     /**
-     * The "goodness" score of the column. Ranges from 1 to {@link numRows}.
+     * The "goodness" score contribution of the column. Ranges from {@code -(seatsPerRow - 1) / 2} (rightmost seat) to
+     * {@code (seatsPerRow - 1) / 2} (leftmost seat), with seats closer to the center scoring closer to 0.
      *
-     * @param col column number of the seat, from 0 to seatsPerRow / 2
-     * @return the "goodness" score - relative to the size of the venue, the lower the better, minimum of 0
+     * @param col column number of the seat, from 0 to {@code seatsPerRow - 1} (inclusive)
+     * @return the "goodness" score - relative to the size of the venue, the closer to 0 the better
      */
     double getXPosition(final int col) {
         checkArgument(col >= 0 && col < seatsPerRow, "col must be between %s and %s (inclusive)", 0, seatsPerRow - 1);

--- a/src/main/java/org/dreesbach/ticketing/SeatHold.java
+++ b/src/main/java/org/dreesbach/ticketing/SeatHold.java
@@ -15,8 +15,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * Class to coordinate holding of seats prior to actually reserving.
  */
 class SeatHold {
-    /** How long the seat hold is kept before expiring. */
-    private static final Duration SEAT_HOLD_EXPIRATION_TIME = Duration.ofMinutes(5);
     /** The expiration time of this {@code SeatHold}. */
     private Instant expirationTime;
     /** Number of seats to hold for reservation. */
@@ -25,17 +23,6 @@ class SeatHold {
     private int id;
     /** List of seats held. */
     private List<Seat> seatsHeld = new ArrayList<>();
-
-    /**
-     * Create a new SeatHold.
-     *
-     * Will auto-generate an ID.
-     *
-     * @param seatsToHold list of seats to hold
-     */
-    SeatHold(final List<Seat> seatsToHold) {
-        this(seatsToHold, SEAT_HOLD_EXPIRATION_TIME);
-    }
 
     /**
      * Create a new SeatHold with the specified expiration time.

--- a/src/main/java/org/dreesbach/ticketing/TicketServiceImpl.java
+++ b/src/main/java/org/dreesbach/ticketing/TicketServiceImpl.java
@@ -40,7 +40,7 @@ public final class TicketServiceImpl implements TicketService {
      * <p>
      * Can be a simple rectangular arrangement, or more complex.
      */
-    private Venue venue;
+    private final Venue venue;
     /**
      * List of all the seat holds.
      */

--- a/src/test/java/org/dreesbach/ticketing/SeatHoldTest.java
+++ b/src/test/java/org/dreesbach/ticketing/SeatHoldTest.java
@@ -21,6 +21,7 @@ class SeatHoldTest {
     private static final List<Seat> SEATS_TO_HOLD = Arrays.asList(new SeatImpl[]{
             new SeatImpl("seat1", 1.0), new SeatImpl("seat2", 2.0)
     });
+    private static final Duration ARBITRARY_EXPIRATION_TIME = Duration.ofMinutes(5);
     private RectangularVenue venue;
 
     @BeforeEach
@@ -32,13 +33,13 @@ class SeatHoldTest {
     @Test
     void getNumSeats() {
         int numSeatsToRequest = 2;
-        SeatHold seatHold = new SeatHold(SEATS_TO_HOLD);
+        SeatHold seatHold = new SeatHold(SEATS_TO_HOLD, ARBITRARY_EXPIRATION_TIME);
         assertEquals(numSeatsToRequest, seatHold.getNumSeatsHeld(), "Number of seats held should equal requested seats");
     }
 
     @Test
     void testHoldingZeroSeats() {
-        SeatHold seatHold = new SeatHold(Collections.emptyList());
+        SeatHold seatHold = new SeatHold(Collections.emptyList(), ARBITRARY_EXPIRATION_TIME);
         assertEquals(0, seatHold.getNumSeatsRequested(), "Number of seats held should equal requested seats (0)");
     }
 
@@ -53,7 +54,7 @@ class SeatHoldTest {
 
     @Test
     void requestMoreSeatsThanAvailable() {
-        SeatHold seatHold = new SeatHold(venue.getSeats());
+        SeatHold seatHold = new SeatHold(venue.getSeats(), ARBITRARY_EXPIRATION_TIME);
         assertEquals(
                 venue.getTotalNumSeats(),
                 seatHold.getNumSeatsHeld(),


### PR DESCRIPTION
## Summary
Cleans up the remaining minor/style items from the earlier repo critique:

- **`SeatHold`'s dead-in-production 1-arg constructor**: it was only ever called from tests (never from `src/main`, which always passes an explicit expiration duration), and it duplicated its own "5 minutes" default separately from `TicketServiceImpl.DEFAULT_SEAT_HOLD_EXPIRATION_TIME` - two independent defaults that could drift out of sync. Removed the constructor and its constant; the 3 call sites in `SeatHoldTest` now pass an explicit duration.
- **`RectangularVenue.getYPosition()`/`getXPosition()` Javadoc**: claimed a 1-indexed range ("from 1 to n") and referenced the wrong field (`{@link numRows}` on the column method), when both are actually 0-indexed and `getXPosition` can go negative for columns past center. Fixed the docs to describe actual behavior.
- **`TicketServiceImpl.venue`**: made `final` - it's only ever assigned once, in the constructor.
- **CI workflow step name**: `"Set up JDK 1.24"` was leftover `1.x`-style naming from before `java-version` was bumped to `24`; renamed to `"Set up JDK 24"`.
- **`.deepsource.toml`**: `runtime_version` was left at the stale default of `"8"` while the project targets Java 24. DeepSource's Java analyzer only supports OpenJDK 8-21 (verified against their docs), so this caps it at `"21"` (the closest supported) with a comment explaining why it can't match the project's actual target.

## Test plan
- [x] `mvn test` - all 130 tests pass
- [x] `mvn verify` - Checkstyle (0 violations) and SpotBugs both pass