### PR TITLE
Address ultrareview nits from #275

### DIFF
--- a/src/main/java/org/dreesbach/ticketing/RectangularVenue.java
+++ b/src/main/java/org/dreesbach/ticketing/RectangularVenue.java
@@ -90,12 +90,12 @@ final class RectangularVenue implements Venue {
 
     /**
      * Get the overall "goodness" score of the seat. The assumption here is that the closer to the front and the closer to the
-     * middle, the better the seat. In other words the "goodness" is maximum front row, center seat, and then decreases in
-     * concentric shells from there, with preference given to seats further forward.
+     * middle, the better the seat. In other words the "goodness" is minimum at the front row, center seat, and then increases
+     * in concentric shells from there, with preference given to seats further forward.
      *
      * @param row row number of the seat, from 0 to n
      * @param col column number of the seat, from 0 to n
-     * @return the "goodness" score - relative to the size of the venue, the higher the better, minimum of 1
+     * @return the "goodness" score - relative to the size of the venue, the lower the better, minimum of 0
      */
     double getGoodness(final int row, final int col) {
         checkArgument(row >= 0 && row < numRows, "row must be between %s and %s (inclusive)", 0, numRows - 1);

--- a/src/main/java/org/dreesbach/ticketing/Seat.java
+++ b/src/main/java/org/dreesbach/ticketing/Seat.java
@@ -55,7 +55,7 @@ public interface Seat {
     /**
      * Return a measure of the seat's "goodness", i.e. how desirable the seat is.
      *
-     * @return an int that measures how good the seat is - higher number = better seat
+     * @return a value that measures how good the seat is - lower number = better seat
      */
     double seatGoodness();
 }

--- a/src/main/java/org/dreesbach/ticketing/TicketServiceImpl.java
+++ b/src/main/java/org/dreesbach/ticketing/TicketServiceImpl.java
@@ -44,12 +44,12 @@ public final class TicketServiceImpl implements TicketService {
     /**
      * List of all the seat holds.
      */
-    private Map<Integer, SeatHold> seatHolds;
+    private final Map<Integer, SeatHold> seatHolds;
     /**
      * An executor service to periodically go through existing {@link SeatHold}s and expire them if they have exceeded their
      * maximum lifetime.
      */
-    private ScheduledExecutorService seatHoldExpiration = new ScheduledThreadPoolExecutor(1);
+    private final ScheduledExecutorService seatHoldExpiration = new ScheduledThreadPoolExecutor(1);
 
     /**
      * Default constructor.


### PR DESCRIPTION
## Summary
Follow-up on the ultrareview of #275 (which merged before these landed). Two nits:

- `TicketServiceImpl.seatHolds` and `seatHoldExpiration` have the same single-assignment lifecycle as `venue` (promoted to `final` in #275) but were left non-final. Made them `final` too for consistency.
- `RectangularVenue.getGoodness()`'s Javadoc still said "maximum front row... higher the better, minimum of 1", contradicting the `getYPosition()`/`getXPosition()` docs #275 already fixed to say lower-is-better. Flipped it to match actual behavior (front-center is the minimum, score increases outward via sum of squares). Also fixed the same inverted claim on `Seat.seatGoodness()` (which was additionally mistyped as returning "an int" when it returns a `double`).

## Test plan
- [x] `mvn test` - all 130 tests pass
- [x] `mvn verify` - Checkstyle (0 violations) and SpotBugs both pass